### PR TITLE
fix problem HTTP可以使用UDP吗？

### DIFF
--- a/Computer Network.md
+++ b/Computer Network.md
@@ -180,7 +180,6 @@ UDP接收方收到报文后，不需要给出任何确认
 
 <details>
 <summary>展开</summary>
-
 对某些实时性要求比较高的情况，选择UDP，比如游戏，媒体通信，实时视频流（直播），即使出现传输错误也可以容忍；其它大部分情况下，HTTP都是用TCP，因为要求传输的内容可靠，不出现丢失
 </details>
 
@@ -188,7 +187,7 @@ UDP接收方收到报文后，不需要给出任何确认
 
 <details>
 <summary>展开</summary>
-
+HTTP不可以使用UDP，HTTP需要基于可靠的传输协议，而UDP不可靠
 
 </details>
 


### PR DESCRIPTION
Computer Network.md   TCP与UDP的区别中 给问题HTTP可以使用UDP吗？添加了答案 

答案依据：
HTTP communication usually takes place over TCP/IP connections. The default port is TCP 80 , but other ports can be used. This does  not preclude HTTP from being implemented on top of any other protocol  on the Internet, or on other networks. HTTP only presumes a reliable  transport; any protocol that provides such guarantees can be used;  the mapping of the HTTP/1.1 request and response structures onto the  transport data units of the protocol in question is outside the scope    of this specification.”——RFC2616